### PR TITLE
add: A/B Setup

### DIFF
--- a/src/app/(sst)/school-of-technology/layout.tsx
+++ b/src/app/(sst)/school-of-technology/layout.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import type { Metadata } from 'next';
 
 import { AnnouncementStrip, Header } from '@components/common';
@@ -8,15 +7,6 @@ import { AlumniProvider } from '@modules/sst/alumni-directory/context/AlumniCont
 import { METADATA } from '@utils/common/metadata';
 import { ANNOUNCEMENT_STRIP_CONTENT } from '@utils/sst/constants';
 
-import {
-  Analytics,
-  AnalyticsFallback,
-  MicrosoftClarity,
-} from '@/components/common/Analytics';
-import {
-  PRODUCTS,
-  SUB_PRODUCTS,
-} from '@/components/common/Analytics/constants';
 
 export const metadata: Metadata = METADATA.SST;
 
@@ -32,16 +22,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         />
         <Navbar />
       </Header>
-
       <main>{children}</main>
-
-      <Suspense key="gtm-script" fallback={<AnalyticsFallback />}>
-        <Analytics
-          product={PRODUCTS.SCHOOL_OF_TECHNOLOGY}
-          subProduct={SUB_PRODUCTS.ALUMNI_DIRECTORY}
-        />
-        <MicrosoftClarity />
-      </Suspense>
     </AlumniProvider>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,21 @@
 import { ConfigProvider } from 'antd';
 import { AntdRegistry } from '@ant-design/nextjs-registry';
 import { ToastContainer } from 'react-toastify';
+import { Suspense } from 'react';
 
 import { customTheme } from '@hooks/useDeviceType';
 import { fontVariables } from '@lib/fonts';
 import { getAllExperiments } from '@utils/abex/experiment';
+
+import {
+  Analytics,
+  AnalyticsFallback,
+  MicrosoftClarity,
+} from '@/components/common/Analytics';
+import {
+  PRODUCTS,
+  SUB_PRODUCTS,
+} from '@/components/common/Analytics/constants';
 
 import ExperimentsProvider from '@context/ExperimentContext';
 import QueryProvider from '@components/common/Analytics/QueryProvider';
@@ -24,6 +35,14 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <AntdRegistry>
                 {children}
               </AntdRegistry>
+              <Suspense key="gtm-script" fallback={<AnalyticsFallback />}>
+                <Analytics
+                  product={PRODUCTS.SCHOOL_OF_TECHNOLOGY}
+                  subProduct={SUB_PRODUCTS.ALUMNI_DIRECTORY}
+                  experiments={experiments}
+                />
+                <MicrosoftClarity />
+              </Suspense>
             </ExperimentsProvider>  
           </ConfigProvider>
         </QueryProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,20 +5,25 @@ import { ToastContainer } from 'react-toastify';
 
 import { customTheme } from '@hooks/useDeviceType';
 import { fontVariables } from '@lib/fonts';
+import { getAllExperiments } from '@utils/abex/experiment';
 
+import ExperimentsProvider from '@context/ExperimentContext';
 import QueryProvider from '@components/common/Analytics/QueryProvider';
 
 import './globals.css';
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const experiments = await getAllExperiments();
   return (
     <html lang="en" className={fontVariables}>
       <body>
         <QueryProvider>
           <ConfigProvider theme={customTheme}>
-            <AntdRegistry>
-              {children}
-            </AntdRegistry>
+            <ExperimentsProvider defaultExperiments={experiments}>
+              <AntdRegistry>
+                {children}
+              </AntdRegistry>
+            </ExperimentsProvider>  
           </ConfigProvider>
         </QueryProvider>
         <ToastContainer />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import './globals.css';
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const experiments = await getAllExperiments();
+  
   return (
     <html lang="en" className={fontVariables}>
       <body>

--- a/src/components/common/Analytics/Analytics.tsx
+++ b/src/components/common/Analytics/Analytics.tsx
@@ -11,9 +11,11 @@ import useUser from '@/hooks/useUser';
 export default function Analytics({
   product,
   subProduct,
+  experiments,
 }: {
   product: string;
   subProduct: string;
+  experiments: Record<string, string>;
 }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -43,7 +45,6 @@ export default function Analytics({
   }, []);
 
   useEffect(() => {
-    const experiments = fetchExperiments();
     const pageUrl = getURLWithUTMParams(window.location.href);
 
     tracker.pushtoPendingList = true;

--- a/src/components/common/Analytics/Analytics.tsx
+++ b/src/components/common/Analytics/Analytics.tsx
@@ -24,6 +24,9 @@ export default function Analytics({
     isError: isUserFetchError,
   } = useUser();
 
+  // TODO: remove this as curently not setting experiments as data attributes
+  
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const fetchExperiments = () => {
     const elements = document.querySelectorAll('[data-variant-key]');
     const experiments: Record<string, string> = {};

--- a/src/components/common/ExperimentCookies.tsx
+++ b/src/components/common/ExperimentCookies.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useContext } from "react";
+import { ExperimentsContext } from "@context/ExperimentContext";
+import { setCookie } from "cookies-next";
+
+const EXPERIMENTS_COOKIE = "experiments";
+const COOKIE_EXPIRY_MINUTES = 30;
+
+function createCookieString(experiments: Record<string, string>) {
+  return Object.entries(experiments)
+    .map(([key, value]) => `${key}:${value}`)
+    .join(";");
+}
+
+function getCookieAge() {
+  return COOKIE_EXPIRY_MINUTES * 60;
+}
+
+function setExperimentsCookie(experiments: Record<string, string>) {
+  setCookie(EXPERIMENTS_COOKIE, createCookieString(experiments), {
+    maxAge: getCookieAge(),
+    path: "/",
+  });
+}
+
+export default function ExperimentCookies() {
+  const { experiments } = useContext(ExperimentsContext);
+  setExperimentsCookie(experiments);
+  return null;
+}

--- a/src/context/ExperimentContext.tsx
+++ b/src/context/ExperimentContext.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { createContext, useEffect, useState } from "react";
-import { setCookie } from "cookies-next";
-
-const COOKIE_EXPIRY_MINUTES = 30;
-const EXPERIMENTS_COOKIE = "experiments";
+import { createContext, useState } from "react";
+import ExperimentCookies from "@components/common/ExperimentCookies";
 
 interface ExperimentsContextType {
   experiments: Record<string, string>;
@@ -25,32 +22,11 @@ export default function ExperimentsProvider({
 }) {
   const [experiments, setExperiments] = useState(defaultExperiments);
 
-  useEffect(() => {
-    if (Object.keys(experiments).length > 0) {
-      setExperimentsCookie(experiments);
-    }
-  }, [experiments]);
-
   return (
     <ExperimentsContext.Provider value={{ experiments, setExperiments }}>
+      <ExperimentCookies />
       {children}
     </ExperimentsContext.Provider>
   );
 }
 
-function setExperimentsCookie(experiments: Record<string, string>) {
-  setCookie(EXPERIMENTS_COOKIE, createCookieString(experiments), {
-    maxAge: getCookieAge(),
-    path: "/",
-  });
-}
-
-function createCookieString(experiments: Record<string, string>) {
-  return Object.entries(experiments)
-    .map(([key, value]) => `${key}:${value}`)
-    .join(";");
-}
-
-function getCookieAge() {
-  return COOKIE_EXPIRY_MINUTES * 60;
-}

--- a/src/context/ExperimentContext.tsx
+++ b/src/context/ExperimentContext.tsx
@@ -29,8 +29,6 @@ export default function ExperimentsProvider({
     }
   }, [experiments]);
 
-  if (Object.keys(experiments).length === 0) return null;
-
   return (
     <ExperimentsContext.Provider value={{ experiments }}>
       {children}

--- a/src/context/ExperimentContext.tsx
+++ b/src/context/ExperimentContext.tsx
@@ -8,10 +8,12 @@ const EXPERIMENTS_COOKIE = "experiments";
 
 interface ExperimentsContextType {
   experiments: Record<string, string>;
+  setExperiments: (experiments: Record<string, string>) => void;
 }
 
 export const ExperimentsContext = createContext<ExperimentsContextType>({
   experiments: {},
+  setExperiments: () => {},
 });
 
 export default function ExperimentsProvider({
@@ -21,7 +23,7 @@ export default function ExperimentsProvider({
   defaultExperiments: Record<string, string>;
   children: React.ReactNode;
 }) {
-  const [experiments] = useState(defaultExperiments);
+  const [experiments, setExperiments] = useState(defaultExperiments);
 
   useEffect(() => {
     if (Object.keys(experiments).length > 0) {
@@ -30,7 +32,7 @@ export default function ExperimentsProvider({
   }, [experiments]);
 
   return (
-    <ExperimentsContext.Provider value={{ experiments }}>
+    <ExperimentsContext.Provider value={{ experiments, setExperiments }}>
       {children}
     </ExperimentsContext.Provider>
   );

--- a/src/context/ExperimentContext.tsx
+++ b/src/context/ExperimentContext.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { createContext, useEffect, useState } from "react";
+import { setCookie } from "cookies-next";
+
+const COOKIE_EXPIRY_MINUTES = 30;
+const EXPERIMENTS_COOKIE = "experiments";
+
+interface ExperimentsContextType {
+  experiments: Record<string, string>;
+}
+
+export const ExperimentsContext = createContext<ExperimentsContextType>({
+  experiments: {},
+});
+
+export default function ExperimentsProvider({
+  defaultExperiments,
+  children,
+}: {
+  defaultExperiments: Record<string, string>;
+  children: React.ReactNode;
+}) {
+  const [experiments] = useState(defaultExperiments);
+
+  useEffect(() => {
+    if (Object.keys(experiments).length > 0) {
+      setExperimentsCookie(experiments);
+    }
+  }, [experiments]);
+
+  if (Object.keys(experiments).length === 0) return null;
+
+  return (
+    <ExperimentsContext.Provider value={{ experiments }}>
+      {children}
+    </ExperimentsContext.Provider>
+  );
+}
+
+function setExperimentsCookie(experiments: Record<string, string>) {
+  setCookie(EXPERIMENTS_COOKIE, createCookieString(experiments), {
+    maxAge: getCookieAge(),
+    path: "/",
+  });
+}
+
+function createCookieString(experiments: Record<string, string>) {
+  return Object.entries(experiments)
+    .map(([key, value]) => `${key}:${value}`)
+    .join(";");
+}
+
+function getCookieAge() {
+  return COOKIE_EXPIRY_MINUTES * 60;
+}

--- a/src/modules/sst/alumni-directory/components/QuickFilters/QuickFilters.tsx
+++ b/src/modules/sst/alumni-directory/components/QuickFilters/QuickFilters.tsx
@@ -23,7 +23,7 @@ export default function QuickFilters() {
   const trackFilterClick = (filter: string, isSelected: boolean) => {
     trackEvent.click({
       clickType: isSelected ? pageTrackingEvents.filterApplied : pageTrackingEvents.filterRemoved,
-      clickText: pageTrackingEvents.filterApplied,
+      clickText: isSelected ? pageTrackingEvents.filterApplied : pageTrackingEvents.filterRemoved,
       clickSource: pageTrackingSources.quickFilters,
       custom: {
         filter_name: filter,

--- a/src/utils/abex/api.ts
+++ b/src/utils/abex/api.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { headers } from "next/headers";
 import { ABEX_API_URL, ABEX_REQUEST_HEADERS } from "./constants";
 
 export async function getAbExperimentVariant(payload: {

--- a/src/utils/abex/api.ts
+++ b/src/utils/abex/api.ts
@@ -1,0 +1,24 @@
+'use server';
+
+import { headers } from "next/headers";
+import { ABEX_API_URL, ABEX_REQUEST_HEADERS } from "./constants";
+
+export async function getAbExperimentVariant(payload: {
+  flagkey: string;
+}) {
+  try {
+    const res = await fetch(`${ABEX_API_URL}/api/v1/evaluation`, {
+      method: "POST",
+      credentials: "include",
+      headers: ABEX_REQUEST_HEADERS,
+      body: JSON.stringify(payload),
+      cache: "no-cache",
+    });
+    const resJson = await res.json();
+    const { flagKey, variantKey } = resJson;
+
+    return { flagKey, variantKey };
+  } catch (error) {
+    console.error('error while fetching abex variant on server', error);
+  }
+}

--- a/src/utils/abex/constants.ts
+++ b/src/utils/abex/constants.ts
@@ -1,0 +1,29 @@
+//add A/B Experiments here
+export const ABEX_FLAG_CONFIG = {
+  BOTTOM_NAVBAR: {
+    KEY: 'sst_bottom_navbar',
+    DEFAULT_VARIANT: 'hide_sst_bottom_navbar',
+  },
+};
+
+
+// ABEX API CALLS
+
+const {
+  ABEX_BASIC_AUTH_USERNAME,
+  ABEX_BASIC_AUTH_PASSWORD,
+  ABEX_BASE_URL,
+} = process.env;
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const ABEX_AUTH_TOKEN = `Basic ${btoa(`${ABEX_BASIC_AUTH_USERNAME}:${ABEX_BASIC_AUTH_PASSWORD}`)}`;
+
+export const ABEX_API_URL = `https://${ABEX_BASE_URL}`;
+
+export const ABEX_REQUEST_HEADERS = {
+  Accept: "application/json",
+  "Content-Type": "application/json",
+  "X-Requested-With": "XMLHttpRequest",
+  ...(isProduction && { Authorization: ABEX_AUTH_TOKEN }),
+};

--- a/src/utils/abex/experiment.ts
+++ b/src/utils/abex/experiment.ts
@@ -1,0 +1,66 @@
+import { cookies } from "next/headers";
+import { setCookie } from 'cookies-next';
+import { ABEX_FLAG_CONFIG } from "./constants";
+import { getAbExperimentVariant } from "./api";
+
+const COOKIE_EXPIRY_MINUTES = 30;
+const EXPERIMENTS_COOKIE = "experiments";
+
+interface AbexPayload {
+  flagkey: string;
+}
+
+const bottomNavbarAbexPayload: AbexPayload = {
+  flagkey: ABEX_FLAG_CONFIG.BOTTOM_NAVBAR.KEY,
+};
+
+export const getAllExperiments = async () => {
+  const cookieStore = await cookies();
+  const experimentsCookieValue = cookieStore.get(EXPERIMENTS_COOKIE)?.value;
+  const experiments = getCurrentExperiments(experimentsCookieValue as string);
+  const bottomNavbarVariant = experiments[bottomNavbarAbexPayload.flagkey];
+
+  const fetchExperiments = [];
+
+  console.log("experimentsCookieValue", experimentsCookieValue);
+
+  if (!bottomNavbarVariant) {
+    experiments[ABEX_FLAG_CONFIG.BOTTOM_NAVBAR.KEY] = ABEX_FLAG_CONFIG.BOTTOM_NAVBAR.DEFAULT_VARIANT;
+    fetchExperiments.push(getAbExperimentVariant(bottomNavbarAbexPayload));
+  }
+
+  if (fetchExperiments.length) {
+    console.log("abex api call");
+    try {
+      const serverPromiseResults = await Promise.allSettled(fetchExperiments);
+      serverPromiseResults.forEach((result) => {
+        if (result.status === "fulfilled") {
+          const { flagKey, variantKey } = result.value as {
+            flagKey: string;
+            variantKey: string;
+          };
+          experiments[flagKey] = variantKey;
+        }
+      });
+    } catch (error) {
+      // console.error("Failed to fetch or set experiments:", error);
+    }
+  }
+
+  console.log("experiments", experiments)
+  return experiments;
+};
+
+function getCurrentExperiments(experimentCookieVal: string): Record<string, string> {
+  const experiments: Record<string, string> = {};
+  if (experimentCookieVal) {
+    const experimentsArr = experimentCookieVal.split(";");
+    experimentsArr.forEach((experiment) => {
+      const [key, val] = experiment.split(":");
+      if (key && val) {
+        experiments[key] = val;
+      }
+    });
+  }
+  return experiments;
+}

--- a/src/utils/abex/experiment.ts
+++ b/src/utils/abex/experiment.ts
@@ -1,9 +1,7 @@
 import { cookies } from "next/headers";
-import { setCookie } from 'cookies-next';
 import { ABEX_FLAG_CONFIG } from "./constants";
 import { getAbExperimentVariant } from "./api";
 
-const COOKIE_EXPIRY_MINUTES = 30;
 const EXPERIMENTS_COOKIE = "experiments";
 
 interface AbexPayload {
@@ -22,15 +20,12 @@ export const getAllExperiments = async () => {
 
   const fetchExperiments = [];
 
-  console.log("experimentsCookieValue", experimentsCookieValue);
-
   if (!bottomNavbarVariant) {
     experiments[ABEX_FLAG_CONFIG.BOTTOM_NAVBAR.KEY] = ABEX_FLAG_CONFIG.BOTTOM_NAVBAR.DEFAULT_VARIANT;
     fetchExperiments.push(getAbExperimentVariant(bottomNavbarAbexPayload));
   }
 
   if (fetchExperiments.length) {
-    console.log("abex api call");
     try {
       const serverPromiseResults = await Promise.allSettled(fetchExperiments);
       serverPromiseResults.forEach((result) => {
@@ -39,15 +34,17 @@ export const getAllExperiments = async () => {
             flagKey: string;
             variantKey: string;
           };
-          experiments[flagKey] = variantKey;
+          if(variantKey) {
+            experiments[flagKey] = variantKey;
+          }
         }
       });
     } catch (error) {
-      // console.error("Failed to fetch or set experiments:", error);
+      //eslint-disable-next-line no-console
+      console.error("Failed to fetch or set experiments:", error);
     }
   }
 
-  console.log("experiments", experiments)
   return experiments;
 };
 


### PR DESCRIPTION
# Description
Added A/B experiment setup for this repo

# Testcases:

1. Tested abex api call

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/29ce01f2-215b-45cf-8d50-2fe3556c6207" />

2. Tested for an experiment if not found on abex , should set default variant

<video src="https://github.com/user-attachments/assets/e5cbf94d-c143-4e24-a201-836afa6129a7" width="200"></video>

3. Tested for 50:50 split

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/2c0dcacf-d7bf-4fb5-a344-ea8e8f1f8777" />

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/aef90e0f-2773-4c9c-93e8-e7cb65151c01" />

4. Tested ab_experiments for trackings flowing to mixpanel

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/96a57a7b-b6df-4863-8d07-6912246bf829" />


