### PR TITLE
fix(SST): navbar fixes

### DIFF
--- a/src/app/(sst)/school-of-technology/alum-directory/layout.tsx
+++ b/src/app/(sst)/school-of-technology/alum-directory/layout.tsx
@@ -12,6 +12,8 @@ import {
   SUB_PRODUCTS,
 } from '@/components/common/Analytics/constants';
 
+import BottomNavbar from "@components/Sst/BottomNavbar";
+
 import { getAllExperiments } from '@utils/abex/experiment';
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
@@ -30,6 +32,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
       <AlumniProvider>
         {children}
       </AlumniProvider>
+      <BottomNavbar />
     </>
   );
 }

--- a/src/app/(sst)/school-of-technology/career-outcomes/layout.tsx
+++ b/src/app/(sst)/school-of-technology/career-outcomes/layout.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from 'react';
 
+import { ABEX_FLAG_CONFIG } from '@utils/abex/constants';
+
 import {
   Analytics,
   AnalyticsFallback,
@@ -10,6 +12,7 @@ import {
   SUB_PRODUCTS,
 } from '@/components/common/Analytics/constants';
 
+import BottomNavbar from '@components/Sst/BottomNavbar';
 import { getAllExperiments } from '@utils/abex/experiment';
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
@@ -26,6 +29,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
         <MicrosoftClarity />
       </Suspense>
       {children}
+      <BottomNavbar variant={ABEX_FLAG_CONFIG.SST_LP_REVAMP.NEW_VARIANT} />
     </>
   );
 }

--- a/src/app/(sst)/school-of-technology/degree/layout.tsx
+++ b/src/app/(sst)/school-of-technology/degree/layout.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from 'react';
 
+import { ABEX_FLAG_CONFIG } from '@utils/abex/constants';
+
 import {
   Analytics,
   AnalyticsFallback,
@@ -9,6 +11,8 @@ import {
   PRODUCTS,
   SUB_PRODUCTS,
 } from '@/components/common/Analytics/constants';
+
+import BottomNavbar from '@components/Sst/BottomNavbar';
 
 import { getAllExperiments } from '@utils/abex/experiment';
 
@@ -26,6 +30,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
         <MicrosoftClarity />
       </Suspense>
       {children}
+      <BottomNavbar variant={ABEX_FLAG_CONFIG.SST_LP_REVAMP.NEW_VARIANT} />
     </>
   );
 }

--- a/src/app/(sst)/school-of-technology/layout.tsx
+++ b/src/app/(sst)/school-of-technology/layout.tsx
@@ -6,7 +6,6 @@ import { LoginModalWrapper } from "@components/Sst/LoginModalWrapper";
 import { METADATA } from "@utils/common/metadata";
 
 import LoginModalProvider from "@context/sst/LoginModalContext";
-import BottomNavbar from "@components/Sst/BottomNavbar";
 import Footer from "@components/common/Footer";
 
 import styles from "./layout.module.scss";
@@ -21,7 +20,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           <Navbar />
         </Header>
         <main>{children}</main>
-        <BottomNavbar />
         <Footer />  
         <LoginModalWrapper />
       </LoginModalProvider>

--- a/src/components/Sst/BottomNavbar/BottomNavbar.tsx
+++ b/src/components/Sst/BottomNavbar/BottomNavbar.tsx
@@ -13,7 +13,7 @@ import {
 
 import SstBottomNudge from '@components/Sst/BottomNudge';
 
-import { BOTTOM_NAVBAR_LINKS, BOTTOM_NAVBAR_LINKS_REVAMP } from './data';
+import { BOTTOM_NAVBAR_LINKS, BOTTOM_NAVBAR_LINKS_REVAMP, REVAMP_VARIANT_PAGES } from './data';
 
 import styles from './BottomNavbar.module.scss';
 import ApplyButton from '@components/Sst/ApplyButton';
@@ -31,7 +31,7 @@ export default function BottomNavbar() {
     });
   };
 
-  if (isRevampedVersion) {
+  if (isRevampedVersion || REVAMP_VARIANT_PAGES.includes(window.location.pathname)) {
     return (
       <>
         <div className={styles.wrapper}>

--- a/src/components/Sst/BottomNavbar/BottomNavbar.tsx
+++ b/src/components/Sst/BottomNavbar/BottomNavbar.tsx
@@ -13,14 +13,14 @@ import {
 
 import SstBottomNudge from '@components/Sst/BottomNudge';
 
-import { BOTTOM_NAVBAR_LINKS, BOTTOM_NAVBAR_LINKS_REVAMP, REVAMP_VARIANT_PAGES } from './data';
+import { BOTTOM_NAVBAR_LINKS, BOTTOM_NAVBAR_LINKS_REVAMP } from './data';
 
 import styles from './BottomNavbar.module.scss';
 import ApplyButton from '@components/Sst/ApplyButton';
 
-export default function BottomNavbar() {
+export default function BottomNavbar({ variant = ''}: { variant?: string }) {
   const { experiments } = useContext(ExperimentsContext);
-  const revampedVariant = experiments[ABEX_FLAG_CONFIG.SST_LP_REVAMP.KEY];
+  const revampedVariant = variant || experiments[ABEX_FLAG_CONFIG.SST_LP_REVAMP.KEY];
   const isRevampedVersion = revampedVariant === ABEX_FLAG_CONFIG.SST_LP_REVAMP.NEW_VARIANT;
 
   const trackEventHandler = (clickText: string) => {
@@ -31,7 +31,7 @@ export default function BottomNavbar() {
     });
   };
 
-  if (isRevampedVersion || REVAMP_VARIANT_PAGES.includes(window.location.pathname)) {
+  if (isRevampedVersion) {
     return (
       <>
         <div className={styles.wrapper}>

--- a/src/components/Sst/BottomNavbar/BottomNavbar.tsx
+++ b/src/components/Sst/BottomNavbar/BottomNavbar.tsx
@@ -39,6 +39,7 @@ export default function BottomNavbar() {
             <ApplyButton
               className={styles.actionButton}
               size="large"
+              shouldTrack={true}
               trackEventSource={pageTrackingSources.bottomNavbar}
               block
             />

--- a/src/components/Sst/BottomNavbar/data.ts
+++ b/src/components/Sst/BottomNavbar/data.ts
@@ -58,3 +58,8 @@ export const BOTTOM_NAVBAR_LINKS_REVAMP = [
     active: true,
   },
 ]
+
+export const REVAMP_VARIANT_PAGES = [
+  '/school-of-technology/degree/',
+  '/school-of-technology/career-outcomes/'
+]

--- a/src/components/Sst/BottomNavbar/data.ts
+++ b/src/components/Sst/BottomNavbar/data.ts
@@ -58,8 +58,3 @@ export const BOTTOM_NAVBAR_LINKS_REVAMP = [
     active: true,
   },
 ]
-
-export const REVAMP_VARIANT_PAGES = [
-  '/school-of-technology/degree/',
-  '/school-of-technology/career-outcomes/'
-]

--- a/src/components/Sst/BottomNudge/BottomNudge.tsx
+++ b/src/components/Sst/BottomNudge/BottomNudge.tsx
@@ -16,7 +16,7 @@ export default function SstBottomNudge() {
           Admissions Open for <span>2025</span>
         </div>
       )}
-      <ApplyButton className={styles.applyButton} trackEventSource="bottom_sticky_navbar"/>
+      <ApplyButton className={styles.applyButton} shouldTrack={true} trackEventSource="bottom_sticky_navbar"/>
     </div>
   );
 }

--- a/src/components/common/Navbar/Navbar.module.scss
+++ b/src/components/common/Navbar/Navbar.module.scss
@@ -14,10 +14,6 @@
   align-items: center;
   align-self: stretch;
   background: $white-color;
-
-  @include tablet {
-    padding: 1.4rem 1.6rem;
-  }
 }
 
 .logoImage {

--- a/src/modules/sst/waitlist/components/OTPStep/index.tsx
+++ b/src/modules/sst/waitlist/components/OTPStep/index.tsx
@@ -58,6 +58,8 @@ export const OTPStep: React.FC<OTPStepProps> = ({
   }, [timeLeft]);
 
   const formattedErrors = (error: any) => {
+    if (typeof error !== 'object') return error;
+    
     const formattedErrors: Record<string, string> = {};
 
     Object.entries(error).forEach(([field, value]: [string, any]) => {

--- a/src/modules/sst/waitlist/components/PhoneEmailStep/index.tsx
+++ b/src/modules/sst/waitlist/components/PhoneEmailStep/index.tsx
@@ -39,6 +39,8 @@ export const PhoneEmailStep: React.FC<PhoneEmailStepProps> = ({
   const [formError, setFormError] = React.useState<string | null>(null);
 
   const formattedErrors = (error: any) => {
+    if (typeof error !== 'object') return error;
+    
     const formattedErrors: Record<string, string> = {};
 
     Object.entries(error).forEach(([field, value]: [string, any]) => {

--- a/src/modules/sst/waitlist/components/WaitlistForm/index.tsx
+++ b/src/modules/sst/waitlist/components/WaitlistForm/index.tsx
@@ -106,6 +106,8 @@ export const WaitlistForm: React.FC<WaitlistFormProps> = ({
   );
 
   const formattedErrors = (error: any) => {
+    if (typeof error !== 'object') return error;
+    
     const formattedErrors: Record<string, string> = {};
 
     Object.entries(error).forEach(([field, value]: [string, any]) => {


### PR DESCRIPTION
# Description
In this PR, i have fixed the bottom navbar variant for degree & outcome Page

Staging Link: [https://19.staging.sclr.ac/school-of-technology/career-outcomes/](https://19.staging.sclr.ac/school-of-technology/career-outcomes/)

# Testcase:
1. Tested with hide_new_page variant

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/820626a6-f782-4b20-b3d5-1f0c37387f17" />


2. Tested with show_new_page variant

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c371bd64-4bec-4247-9bad-3907c2d265f0" />

3. Testes both variants for alum directory

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/014ae17c-2700-46a3-9218-af487ab4f2e0" />

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/760dc4a4-c0b9-46e3-a21a-ee87da7b1079" />
