### PR TITLE
feat[SST]: Updated copy for internship stipend on career-outcomes page

### DIFF
--- a/src/modules/sst/career-outcomes/utils/data.tsx
+++ b/src/modules/sst/career-outcomes/utils/data.tsx
@@ -101,7 +101,7 @@ export const higherStudiesCardData: HigherStudiesCardProps[] = [
 export const CareerStatsData = {
   stats: [
     {
-      title: "1.13 Lakh / Month",
+      title: "2 Lakh / Month",
       desc: "Highest 2nd Year Internship Stipend",
       image: BurstBgImage.src,
       variant: "primary",


### PR DESCRIPTION
Updated the highest internship stipend from `1.13 Lakh/Month` to `2 Lakh/Month`

![image](https://github.com/user-attachments/assets/ef6a57f3-22a4-4eb8-9e0d-789d88c7e98f)
![image](https://github.com/user-attachments/assets/fb560dd4-44c3-4e33-bb78-cda9e2c90c0d)
