### PR TITLE
fixed news section in ios devices

### DIFF
--- a/src/modules/ssb/landing_v2/constants/index.ts
+++ b/src/modules/ssb/landing_v2/constants/index.ts
@@ -54,7 +54,6 @@ import HinduDesktop from '@public/images/ssb/hindudesktop.webp';
 import BrainfedDesktop from '@public/images/ssb/brainfeeddesktop.webp';
 import OutlookDesktop from '@public/images/ssb/outlookdesktop.webp';
 import TimeDesktop from '@public/images/ssb/timedesktop.webp';
-import TitleHeadline from '@public/images/ssb/news_title.webp';
 import uber_with_frame from '@public/images/ssb/uber_with_frame.webp';
 import mckinsey_with_frame from '@public/images/ssb/mckinsey_with_frame.webp';
 import colgate from '@public/images/ssb/colgate.webp';

--- a/src/modules/ssb/landing_v2/constants/index.ts
+++ b/src/modules/ssb/landing_v2/constants/index.ts
@@ -327,7 +327,9 @@ export const STUDENT_FEATURE_CONTAINER = {
 }
 
 export const NEWS_CONTAINER = {
-  titleHeadline: TitleHeadline.src,
+  titleHeadline: 'Featured in the ',
+  titleHightlight: 'News',
+  subtitle: "See what Scaler has been up to and it’s presence in articles published in the news",
   newsCards: [
     {
       image: HinduDesktop,

--- a/src/modules/ssb/landing_v2/ui/NewsContainer/NewsContainer.module.scss
+++ b/src/modules/ssb/landing_v2/ui/NewsContainer/NewsContainer.module.scss
@@ -9,9 +9,11 @@
 }
 
 .headlineContainer {
+  @include flex-col-c;
+
   width: 100%;
-  align-items: flex-start;
-  overflow: hidden;
+  height: 100%;
+  gap: 1.6rem;
 }
 
 .newsCardContainer {
@@ -25,39 +27,31 @@
   }
 }
 
-.featuredNewsTitleImg {
-  @include flex-row;
-  width: max-content;
-  flex-wrap: nowrap;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 1rem;
-  animation: horizontal-scroll 60s linear infinite;
+.titleHeadline {
+  font-size: 4rem;
+  line-height: 4.8rem;
+  font-family: 'Montserrat';
+  text-align: center;
 
-  img {
-    width: 100%;
-    height: 6.6rem;
-    object-fit: cover;
-  }
-
-  &--reverse {
-    animation-direction: reverse;
+  @include tablet {
+    font-size: 1.8rem;
+    line-height: 2.4rem;
   }
 }
 
-@keyframes horizontal-scroll {
-  0% {
-    transform: translateX(0%);
-  }
-  100% {
-    transform: translateX(-50%);
-  }
+.titleHightlight {
+  color: #1A8452;
+  font-weight: 600;
 }
 
-@media (max-width: 600px) {
-  .featuredNewsTitleImg {
-    img {
-      height: 2.9rem;
-    }
+.subtitle {
+  font-size: 2.4rem;
+  line-height: 3.4rem;
+  color: #3A3A3A;
+  text-align: center;
+
+  @include tablet {
+    font-size: 1.4rem;
+    line-height: 2rem;
   }
 }

--- a/src/modules/ssb/landing_v2/ui/NewsContainer/NewsContainer.tsx
+++ b/src/modules/ssb/landing_v2/ui/NewsContainer/NewsContainer.tsx
@@ -18,33 +18,13 @@ export default function NewsContainer() {
     <Section section_class="news-container" id="news-container">
       <div className={`${styles.newsContainer} news-section`}>
         <div className={styles.headlineContainer}>
-          <div className={styles.featuredNewsTitleImg}>
-            <img
-              src={NEWS_CONTAINER.titleHeadline}
-              alt="Title Headline"
-              className={styles.titleHeadline}
-            />
-            <img
-              src={NEWS_CONTAINER.titleHeadline}
-              alt="Title Headline"
-              className={styles.titleHeadline}
-            />
+          <div className={styles.titleHeadline}>
+            {NEWS_CONTAINER.titleHeadline}
+            <span className={styles.titleHightlight}>
+              {NEWS_CONTAINER.titleHightlight}
+            </span>
           </div>
-
-          <div
-            className={`${styles.featuredNewsTitleImg} ${styles["featuredNewsTitleImg--reverse"]}`}
-          >
-            <img
-              src={NEWS_CONTAINER.titleHeadline}
-              alt="Title Headline"
-              className={styles.titleHeadline}
-            />
-            <img
-              src={NEWS_CONTAINER.titleHeadline}
-              alt="Title Headline"
-              className={styles.titleHeadline}
-            />
-          </div>
+          <div className={styles.subtitle}>{NEWS_CONTAINER.subtitle}</div>
         </div>
 
         <div className={styles.newsCardContainer}>


### PR DESCRIPTION
Fixing a bug in ios devices for ssb minimal landing news section

## Previous
<img width="757" alt="Screenshot 2025-05-21 at 11 19 59 AM" src="https://github.com/user-attachments/assets/b0f8b00b-96aa-4c00-a54e-4b707b225413" />

## Now
<img width="766" alt="Screenshot 2025-05-21 at 11 20 34 AM" src="https://github.com/user-attachments/assets/69bf8166-8c69-4ee7-bdbb-b7122919a057" />
